### PR TITLE
Change Brands and Categories input types to Select

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -349,18 +349,22 @@ ___TEMPLATE_PARAMETERS___
         "type": "TEXT"
       },
       {
-        "help": "(Optional) A list of categories associated with the product/variant. Must be a JavaScript array of strings (e.g., <code>[\"products\", \"gaming\", \"mouse\"]</code>",
+        "help": "(Optional) A list of categories associated with the product/variant. Must be a JavaScript array of strings (e.g., <code>[\"products\", \"gaming\", \"mouse\"]</code>)",
+        "macrosInSelect": true,
+        "selectItems": [],
         "displayName": "Product categories",
         "simpleValueType": true,
         "name": "categories",
-        "type": "TEXT"
+        "type": "SELECT"
       },
       {
-        "help": "(Optional) A list of brands associated with the product/variant. Must be a JavaScript array of strings (e.g., <code>[\"acme\", \"acmetech\"]</code>",
+        "help": "(Optional) A list of brands associated with the product/variant. Must be a JavaScript array of strings (e.g., <code>[\"acme\", \"acmetech\"]</code>)",
+        "macrosInSelect": true,
+        "selectItems": [],
         "displayName": "Product brands",
         "simpleValueType": true,
         "name": "brands",
-        "type": "TEXT"
+        "type": "SELECT"
       },
       {
         "help": "(Optional) The number of product units that were added to or removed from the cart.",


### PR DESCRIPTION
Brands et Categories prennent un *Array* JavaScript.

J'ai tenté de définir un array en plain text dans l'input et il était escapé:

`brands: "[\"brandA\", \"brandB\"]`"`

Donc le free-text input sert juste à rien.

En mettant le type Select, ça force les gens à choisir une variable. Avec une `JavaScript` variable définie comme suit:

```
function() {
  return ["brandA", "brandB", "brandon"];
}
``` 

ça envoie la valeur suivante:

`brands: ["brandA", "brandB", "brandon"]`

Win ! 🎊 